### PR TITLE
Added AAD v2 support for Microsoft accounts and new issuer

### DIFF
--- a/lib/azure-ad-jwt.js
+++ b/lib/azure-ad-jwt.js
@@ -2,7 +2,7 @@ var exports = module.exports;
 
 exports.AzureActiveDirectoryValidationManager = require('./azure-ad-validation-manager.js');
 
-exports.verify = function(jwtString, options, useV2 = false, callback) {
+exports.verify = function(jwtString, options, fetchCommon = false, useV2issuer = false, callback) {
 
     var aadManager = new exports.AzureActiveDirectoryValidationManager();
 
@@ -14,7 +14,7 @@ exports.verify = function(jwtString, options, useV2 = false, callback) {
         return callback(new Error(-1, 'Not a valid AAD token'), null)
     }
 
-    if(useV2) {
+    if(fetchCommon) {
         // download the common v2.0 open id config
         aadManager.requestOpenIdConfig('common/v2.0', function(err, openIdConfigCommon) {
             // download the signing certificates from Microsoft for common (Microsoft) accounts
@@ -27,7 +27,7 @@ exports.verify = function(jwtString, options, useV2 = false, callback) {
                     aadManager.requestSigningCertificates(openIdConfig.jwks_uri, options, function(err, certificates) {
 
                         // verify against all certificates
-                        aadManager.verify(jwtString, certificates, options, true, callback);
+                        aadManager.verify(jwtString, certificates, options, useV2issuer, callback);
                     })
                 });
             });
@@ -40,7 +40,7 @@ exports.verify = function(jwtString, options, useV2 = false, callback) {
             aadManager.requestSigningCertificates(openIdConfig.jwks_uri, options, function(err, certificates) {
 
                 // verify against all certificates
-                aadManager.verify(jwtString, certificates, options, false, callback);
+                aadManager.verify(jwtString, certificates, options, useV2issuer, callback);
             })
         });
     }

--- a/lib/azure-ad-jwt.js
+++ b/lib/azure-ad-jwt.js
@@ -2,7 +2,7 @@ var exports = module.exports;
 
 exports.AzureActiveDirectoryValidationManager = require('./azure-ad-validation-manager.js');
 
-exports.verify = function(jwtString, options, callback) {
+exports.verify = function(jwtString, options, useV2 = false, callback) {
 
     var aadManager = new exports.AzureActiveDirectoryValidationManager();
 
@@ -14,14 +14,34 @@ exports.verify = function(jwtString, options, callback) {
         return callback(new Error(-1, 'Not a valid AAD token'), null)
     }
 
-    // download the open id config
-    aadManager.requestOpenIdConfig(tenantId, function(err, openIdConfig) {
+    if(useV2) {
+        // download the common v2.0 open id config
+        aadManager.requestOpenIdConfig('common/v2.0', function(err, openIdConfigCommon) {
+            // download the signing certificates from Microsoft for common (Microsoft) accounts
+            aadManager.requestSigningCertificates(openIdConfigCommon.jwks_uri, options, function(err, certificates) {
 
-        // download the signing certificates from Microsoft for this specific tenant
-        aadManager.requestSigningCertificates(openIdConfig.jwks_uri, options, function(err, certificates) {
+                // download the signing certificates from Microsoft for this specific tenant
+                aadManager.requestOpenIdConfig(tenantId, function(err, openIdConfig) {
 
-            // verify against all certificates
-            aadManager.verify(jwtString, certificates, options, callback);
-        })
-    });
+                    // download the signing certificates from Microsoft for this specific tenant
+                    aadManager.requestSigningCertificates(openIdConfig.jwks_uri, options, function(err, certificates) {
+
+                        // verify against all certificates
+                        aadManager.verify(jwtString, certificates, options, true, callback);
+                    })
+                });
+            });
+        });
+    } else {
+        // download the open id config
+        aadManager.requestOpenIdConfig(tenantId, function(err, openIdConfig) {
+
+            // download the signing certificates from Microsoft for this specific tenant
+            aadManager.requestSigningCertificates(openIdConfig.jwks_uri, options, function(err, certificates) {
+
+                // verify against all certificates
+                aadManager.verify(jwtString, certificates, options, false, callback);
+            })
+        });
+    }
 }

--- a/lib/azure-ad-validation-manager.js
+++ b/lib/azure-ad-validation-manager.js
@@ -118,7 +118,7 @@ function AzureActiveDirectoryValidationManager() {
      * This function tries to verify the token with every certificate until
      * all certificates was testes or the first one matches. After that the token is valid
      */
-    self.verify = function(jwt, certificates, options, cb) {
+    self.verify = function(jwt, certificates, v2issuer = false, options, cb) {
 
         // ensure we have options
         if (!options) options = {};
@@ -127,7 +127,10 @@ function AzureActiveDirectoryValidationManager() {
         options.algorithms = ['RS256'];
 
         // set the issuer we expect
-        options.issuer = 'https://sts.windows.net/' + self.getTenantId(jwt) + '/';
+        if(v2issuer) 
+            options.issuer = 'https://login.microsoftonline.com/' + self.getTenantId(jwt) + '/v2.0';
+        else 
+            options.issuer = 'https://sts.windows.net/' + self.getTenantId(jwt) + '/';
 
         var valid = false;
         var lastError = null;


### PR DESCRIPTION
Hi,
I am authenticating using AAD v2.0 and MSAL which means users can login with both 'work and school accounts' and 'Microsoft accounts' (i.e. personal accounts). The app I have registered in Azure is configured with `"signInAudience": "AzureADandPersonalMicrosoftAccount"`

Validation of personal accounts always fails with invalid signature, checking the `kid` value of the JWT token I don't see it in the list of keys found at `https://login.windows.net/{tennantID}/discovery/keys`

After a LOT of hair pulling - I found out these keys are held in a different OpenId Config located at `https://login.windows.net/common/v2.0/.well-known/openid-configuration`

This PR adds a `useV2` boolean option to the verify function, when set to true, the additional common keys/certs are fetched via the `common/v2.0/.well-known/openid-configuration` and then also the tenant specific ones. When set to false only the tenant specific keys are fetched (the old behaviour) 

In addition when `useV2` is set to true, the issuer used by the AzureActiveDirectoryValidationManager.verify() method is changed to 'https://login.microsoftonline.com/{tenantID}/v2.0` rather than the old sts.windows.net one
This should fix the problems in issue #11 