### PR TITLE
Add configurable url templates 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ If you are using Azure AAD tokens in every request against your API additional c
 ## Usage
 
 ```javascript
-var aad     = require('azure-ad-jwt');
+var aad = require('azure-ad-jwt');
 
 var jwtToken = '<<yourtoken>>';
 
@@ -27,9 +27,11 @@ aad.verify(jwtToken, { audience: 'https://graph.windows.net'}, function(err, res
 ```
 
 
+## Options
+Additional options specific to this library
 
-
-
-
-
-
+| Option                       | Format | Description                                                                                                                                                                                                                                                                                | Default                                                                   |
+|------------------------------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
+| `aadOpenIdConfigUrlTemplate` | String | optional string template in the format `https://login.windows.net/{tenantId}/.well-known/openid-configuration`. Allows for config retrieval from various locations. All occurrences of `{tenantId}` in the string will be replaced with the tenant ID (`tid`) in the supplied token claims | `"https://login.windows.net/{tenantId}/.well-known/openid-configuration"` |
+| `aadIssuerUrlTemplate`       | String | optional string template in the format `https://sts.windows.net/{tenantId}/`.  Allows for specific issuer configuration.  All occurrences of `{tenantId}` in the string will be replaced with the tenant ID (`tid`) in the supplied token claims                                           | `"https://login.windows.net/{tenantId}/"`                                 |
+|                              |        |                                                                                                                                                                                                                                                                                            |                                                                           |

--- a/lib/azure-ad-jwt.js
+++ b/lib/azure-ad-jwt.js
@@ -3,6 +3,9 @@ var exports = module.exports;
 exports.AzureActiveDirectoryValidationManager = require('./azure-ad-validation-manager.js');
 
 exports.verify = function(jwtString, options, callback) {
+    if(!options){
+        options = {};
+    }
 
     var aadManager = new exports.AzureActiveDirectoryValidationManager();
 
@@ -15,7 +18,7 @@ exports.verify = function(jwtString, options, callback) {
     }
 
     // download the open id config
-    aadManager.requestOpenIdConfig(tenantId, function(err, openIdConfig) {
+    aadManager.requestOpenIdConfig(tenantId, options.aadOpenIdConfigUrlTemplate, function(err, openIdConfig) {
 
         // download the signing certificates from Microsoft for this specific tenant
         aadManager.requestSigningCertificates(openIdConfig.jwks_uri, options, function(err, certificates) {
@@ -24,4 +27,4 @@ exports.verify = function(jwtString, options, callback) {
             aadManager.verify(jwtString, certificates, options, callback);
         })
     });
-}
+};

--- a/lib/azure-ad-validation-manager.js
+++ b/lib/azure-ad-validation-manager.js
@@ -49,11 +49,19 @@ function AzureActiveDirectoryValidationManager() {
     /*
      * This function loads the open-id configuration for a specific AAD tenant
      * from a well known application.
+     * @param {string} tenantId required tenant ID.
+     * @param {string} [openIdConfigUrlTemplate] optional string template in the format `https://login.windows.net/{tenantId}/.well-known/openid-configuration`
+     * allows for config retrieval from various locations.  All occurrences of `{tenantId}` in the string will be replaced with the supplied tenantId
+     * @param cb callback
      */
-    self.requestOpenIdConfig = function(tenantId, cb) {
+    self.requestOpenIdConfig = function(tenantId, openIdConfigUrlTemplate, cb) {
         // we need to load the tenant specific open id config
+
+        var urlTemplate = openIdConfigUrlTemplate || 'https://login.windows.net/{tenantId}/.well-known/openid-configuration';
+        var url = urlTemplate.split('{tenantId}').join(tenantId);
+
         var tenantOpenIdconfig = {
-          url: 'https://login.windows.net/' + tenantId + '/.well-known/openid-configuration',
+          url: url,
           json: true
         };
 
@@ -126,8 +134,12 @@ function AzureActiveDirectoryValidationManager() {
         // set the correct algorithm
         options.algorithms = ['RS256'];
 
+        var tenantId = self.getTenantId(jwt);
+        var issuerUrlTemplate = options.aadIssuerUrlTemplate || 'https://sts.windows.net/{tenantId}/';
+
         // set the issuer we expect
-        options.issuer = 'https://sts.windows.net/' + self.getTenantId(jwt) + '/';
+        options.issuer = issuerUrlTemplate.split('{tenantId}').join(tenantId)
+            || 'https://sts.windows.net/' + tenantId + '/';
 
         var valid = false;
         var lastError = null;


### PR DESCRIPTION
…for the openId config url and the issuer url, ensuring that this library can be used with domains other than login.windows.net, and for specific api version paths etc..   Would resolve #11 