### PR TITLE
Change error message when token is invalid

### DIFF
--- a/lib/azure-ad-jwt.js
+++ b/lib/azure-ad-jwt.js
@@ -11,7 +11,7 @@ exports.verify = function(jwtString, options, callback) {
 
     // check if it looks like a valid AAD token
     if (!tenantId) {
-        return callback(new Error(-1, 'Not a valid AAD token'), null)
+        return callback(new Error('Not a valid AAD token'), null)
     }
 
     // download the open id config


### PR DESCRIPTION
Currently when reading `error.message`, it shows "-1" instead of the intended "Not a valid AAD token".

Maybe I'm missing the purpose of "-1", but this should fix it.